### PR TITLE
Add support for additional volumes/volumeMounts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: ebpf-exporter
-version: 0.1.0
+version: 0.1.1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Parameter | Description | Default
 `nodeSelector` | node selector rules | `{}`
 `tolerations` | node tolerations | `[]`
 `affinity` | pod affinity rules | `{}`
+`volumes` | additional volumes for the daemonset | `{}`
+`volumeMounts` | additional volumeMounts for the daemonset | `{}`
 
 ## Docker file
 The docker file to build images can be located at

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -39,9 +39,17 @@ spec:
           name: kernel
         - mountPath: /lib/modules/
           name: modules
-      resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
       dnsPolicy: ClusterFirst
+      {{- if not (empty .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if not (empty .Values.tolerations) }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       schedulerName: default-scheduler
       volumes:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
           name: kernel
         - mountPath: /lib/modules/
           name: modules
+        {{- if not (empty .Values.volumeMounts) }}
+        {{- toYaml .Values.volumeMounts | trim | nindent 8 }}
+        {{- end }}
       resources:
             {{- toYaml .Values.resources | nindent 12 }}
       dnsPolicy: ClusterFirst
@@ -57,3 +60,6 @@ spec:
             path: /lib/modules/
             type: Directory
           name: modules
+      {{- if not (empty .Values.volumes) }}
+        {{- toYaml .Values.volumes | trim | nindent 8 }}
+      {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -58,3 +58,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional volumes for the daemonset.
+volumes: ~
+
+# Additional volumeMounts for the daemonset.
+volumeMounts: ~


### PR DESCRIPTION
Adding support for additional `volumes` and `volumeMounts` allows me to work around a problem I have where `ebpf_exporter` can't compile eBPF programs because it can't find Linux kernel sources.

```
kubectl logs -n kube-system ebpf-exporter-7cb547db8f-2pnmv
sh: 1: modprobe: not found
chdir(/lib/modules/4.14.186-146.268.amzn2.x86_64/build): No such file or directory
2020/09/11 04:39:25 Error attaching exporter: error compiling module for program
```

When I look at `/lib/modules/4.14.186-146.268.amzn2.x86_64/build`, I can see it is a symlink to `/usr/kernel/sources`:

```
kubectl exec -it -n kube-system ebpf-exporter-64f7c7f559-cjgkd -- ls -l /lib/modules/4.14.186-146.268.amzn2.x86_64/build
lrwxrwxrwx 1 root root 46 Jul 23 23:03 /lib/modules/4.14.186-146.268.amzn2.x86_64/build -> /usr/src/kernels/4.14.186-146.268.amzn2.x86_64
```

The work around for me is to make sure kernel sources are installed on the host, and mount them into the Docker container. Having `volumes` and `volumesMounts` as Chart variables allows me to mount them like this:

```
volumes:
  - hostPath:
      path: /usr/src/kernels
      type: Directory
    name: kernel-source

volumeMounts:
  - mountPath: /usr/src/kernels
    name: kernel-source
```

I'm not sure if other environments that aren't AWS EKS would have this problem. If so, it might make sense to mount `/usr/src/kernels` from the host directly in this chart, in addition to (or instead of) supporting additional `volumes` and `volumeMounts`.