### PR TITLE
Support supplying alternate command to container

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: ebpf-exporter
-version: 0.1.0
+version: 0.1.1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Parameter | Description | Default
 `nodeSelector` | node selector rules | `{}`
 `tolerations` | node tolerations | `[]`
 `affinity` | pod affinity rules | `{}`
+`command` | supply alternate command to container | `{}`
 
 ## Docker file
 The docker file to build images can be located at

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Parameter | Description | Default
 `nodeSelector` | node selector rules | `{}`
 `tolerations` | node tolerations | `[]`
 `affinity` | pod affinity rules | `{}`
+`volumes` | additional volumes for the daemonset | `{}`
+`volumeMounts` | additional volumeMounts for the daemonset | `{}`
 
 ## Docker file
 The docker file to build images can be located at

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -39,9 +39,17 @@ spec:
           name: kernel
         - mountPath: /lib/modules/
           name: modules
-      resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
       dnsPolicy: ClusterFirst
+      {{- if not (empty .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
+      {{- if not (empty .Values.tolerations) }}
+      tolerations:
+        {{- toYaml .Values.tolerations | trim | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       schedulerName: default-scheduler
       volumes:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -39,6 +39,9 @@ spec:
           name: kernel
         - mountPath: /lib/modules/
           name: modules
+        {{- if not (empty .Values.volumeMounts) }}
+        {{- toYaml .Values.volumeMounts | trim | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | trim | nindent 10 }}
       dnsPolicy: ClusterFirst
@@ -65,3 +68,6 @@ spec:
             path: /lib/modules/
             type: Directory
           name: modules
+      {{- if not (empty .Values.volumes) }}
+        {{- toYaml .Values.volumes | trim | nindent 8 }}
+      {{- end }}

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -24,6 +24,10 @@ spec:
     spec:
       containers:
       - name: {{ .Release.Name  }}
+        {{- if not (empty .Values.command) }}
+        command:
+          {{- toYaml .Values.command | trim | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -58,3 +58,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Additional volumes for the daemonset.
+volumes: ~
+
+# Additional volumeMounts for the daemonset.
+volumeMounts: ~

--- a/values.yaml
+++ b/values.yaml
@@ -58,3 +58,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Override the command for the container.
+command: ~


### PR DESCRIPTION
This Helm chart already supports using an image other than `vanneback/ebpf_exporter`. I don't have any issue with that container, but there are more up-to-date ones available in Dockerhub. I'd like to be able to use those images (or a custom image that I build), while still using this Helm chart.

This PR adds a `command` variable, which can be used to supply an alternate container command. This is necessary for Docker images that don't reference `--config.file=/etc/config/ebpf-config.yaml` in the same way that `ebpf_exporter_dockerfile` does.